### PR TITLE
Listen to error events from Structs while parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Next Release
+------------
+* Update the `Struct` object error-handling to not use events, but rather internal failed state flag.
+
 0.2.0 / 2014-01-16
 ------------------
 * Add parsing of more message types: `alert`, `getblocks`, `getheaders`, `headers`, `notfound`, and `tx`

--- a/examples/app.js
+++ b/examples/app.js
@@ -17,7 +17,7 @@ n.on('error', function error(d) {
   console.log('('+d.severity+'): '+d.message);
 });
 
-n.on('peerStatus', function status(d) {
+n.on('status', function status(d) {
   console.log('PeerManager status:', d);
 });
 

--- a/lib/BTCNetwork.js
+++ b/lib/BTCNetwork.js
@@ -156,13 +156,8 @@ BTCNetwork.prototype.handleListenConnect = function handleListenConnect(d) {
 
 BTCNetwork.prototype._wrapStruct = function _wrapStruct(data, func) {
   var s = new Struct(data);
-  var hasFailed = false;
-  s.on('error', function(err) {
-    hasFailed = true;
-  });
-  
   var rs = func.call(this, s);
-  return (hasFailed)? false : rs;
+  return (s.hasFailed)? false : rs;
 };
 
 BTCNetwork.prototype.parseAddrMessage = function parseAddrMessage(data) {

--- a/lib/BTCNetwork.js
+++ b/lib/BTCNetwork.js
@@ -154,21 +154,14 @@ BTCNetwork.prototype.handleListenConnect = function handleListenConnect(d) {
 
 //// Message parsing/handling methods ////
 
-BTCNetwork.prototype._wrapStruct = function _wrapStruct(data, func) {
-  var s = new Struct(data);
-  var rs = func.call(this, s);
-  return (s.hasFailed)? false : rs;
-};
-
 BTCNetwork.prototype.parseAddrMessage = function parseAddrMessage(data) {
-  return this._wrapStruct(data, function(s) {
-    var addrs = [];
-    var addrNum = s.readVarInt();
-    for (var i = 0; i < addrNum; i++) {
-      addrs.push(this.getAddr(s.raw(30)));
-    }
-    return { addrs: addrs };
-  });
+  var s = new Struct(data);
+  var addrs = [];
+  var addrNum = s.readVarInt();
+  for (var i = 0; i < addrNum; i++) {
+    addrs.push(this.getAddr(s.raw(30)));
+  }
+  return (s.hasFailed)? false : { addrs: addrs };
 };
 
 BTCNetwork.prototype.handleAddrMessage = function handleAddrMessage(data, peer) {
@@ -176,51 +169,46 @@ BTCNetwork.prototype.handleAddrMessage = function handleAddrMessage(data, peer) 
 };
 
 BTCNetwork.prototype.parseAlertMessage = function parseAlertMessage(data) {
-  return this._wrapStruct(data, function(s) {
-    var msgSize = s.readVarInt();
-    var message = s.raw(msgSize);
-    var sigSize = s.readVarInt();
-    var signature = s.raw(sigSize);
-    
-    var parsed = this._wrapStruct(message, function(s) {
-      var parsed = {};
-      parsed.version = s.readUInt32LE();
-      if (parsed.version == 1) {
-        // Original Satoshi client format
-        parsed.relay_until = s.raw(8);
-        if (parsed.relay_until !== false && parsed.relay_until.readUInt32LE(4) == 0) {
-          parsed.relay_until = new Date(parsed.relay_until.readUInt32LE(0)*1000);
-        }
-        parsed.expiration = s.raw(8);
-        if (parsed.expiration !== false && parsed.expiration.readUInt32LE(4) == 0) {
-          parsed.expiration = new Date(parsed.expiration.readUInt32LE(0)*1000);
-        }
-        parsed.uuid = s.readUInt32LE();
-        parsed.cancel = s.readUInt32LE();
-        var num = s.readVarInt();
-        parsed.cancel_set = [];
-        for (var i = 0; i < num; i++) {
-          parsed.cancel_set.push(s.readUInt32LE());
-        }
-        parsed.min_version = s.readUInt32LE();
-        parsed.max_version = s.readUInt32LE();
-        num = s.readVarInt();
-        parsed.subversion_set = [];
-        for (var i = 0; i < num; i++) {
-          parsed.subversion_set.push(s.readVarString());
-        }
-        parsed.priority = s.readUInt32LE();
-        parsed.comment = s.readVarString();
-        parsed.status_bar = s.readVarString();
-        num = s.readVarInt();
-        parsed.reserved = s.raw(num);
-      }
-      return parsed;
-    });
-    if (parsed === false) return false;
-    parsed.signature = signature;
-    return parsed;
-  });
+  var s = new Struct(data);
+  var parsed = {};
+  var msgSize = s.readVarInt();
+  var message = s.raw(msgSize);
+  var sigSize = s.readVarInt();
+  parsed.signature = s.raw(sigSize);
+  
+  var s2 = new Struct(message);
+  parsed.version = s2.readUInt32LE();
+  if (parsed.version == 1) {
+    // Original Satoshi client format
+    parsed.relay_until = s2.raw(8);
+    if (parsed.relay_until !== false && parsed.relay_until.readUInt32LE(4) == 0) {
+      parsed.relay_until = new Date(parsed.relay_until.readUInt32LE(0)*1000);
+    }
+    parsed.expiration = s2.raw(8);
+    if (parsed.expiration !== false && parsed.expiration.readUInt32LE(4) == 0) {
+      parsed.expiration = new Date(parsed.expiration.readUInt32LE(0)*1000);
+    }
+    parsed.uuid = s2.readUInt32LE();
+    parsed.cancel = s2.readUInt32LE();
+    var num = s2.readVarInt();
+    parsed.cancel_set = [];
+    for (var i = 0; i < num; i++) {
+      parsed.cancel_set.push(s2.readUInt32LE());
+    }
+    parsed.min_version = s2.readUInt32LE();
+    parsed.max_version = s2.readUInt32LE();
+    num = s2.readVarInt();
+    parsed.subversion_set = [];
+    for (var i = 0; i < num; i++) {
+      parsed.subversion_set.push(s2.readVarString());
+    }
+    parsed.priority = s2.readUInt32LE();
+    parsed.comment = s2.readVarString();
+    parsed.status_bar = s2.readVarString();
+    num = s2.readVarInt();
+    parsed.reserved = s2.raw(num);
+  }
+  return (s.hasFailed || s2.hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handleAlertMessage = function handleAlertMessage(data, peer) {
@@ -309,17 +297,16 @@ BTCNetwork.prototype.handleGetaddrMessage = function handleGetaddrMessage(data, 
 };
 
 BTCNetwork.prototype.parseGetblocksMessage = function parseGetblocksMessage(data) {
-  return this._wrapStruct(data, function(s) {
-    var parsed = {};
-    parsed.version = s.readUInt32LE();
-    var hashCount = s.readVarInt();
-    parsed.hashes = [];
-    for (var i = 0; i < hashCount; i++) {
-      parsed.hashes.push(s.raw(32));
-    }
-    parsed.hash_stop = s.raw(32);
-    return parsed;
-  });
+  var s = new Struct(data);
+  var parsed = {};
+  parsed.version = s.readUInt32LE();
+  var hashCount = s.readVarInt();
+  parsed.hashes = [];
+  for (var i = 0; i < hashCount; i++) {
+    parsed.hashes.push(s.raw(32));
+  }
+  parsed.hash_stop = s.raw(32);
+  return (s.hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.parseGetheadersMessage = function parseGetHeadersMessage(data) {
@@ -327,22 +314,21 @@ BTCNetwork.prototype.parseGetheadersMessage = function parseGetHeadersMessage(da
 };
 
 BTCNetwork.prototype.parseHeadersMessage = function parseHeadersMessage(data) {
-  return this._wrapStruct(data, function(s) {
-    var headers = [];
-    var num = s.readVarInt();
-    for (var i = 0; i < num; i++) {
-      var header = {};
-      header.version = s.readUInt32LE();
-      header.prev_block = s.raw(32);
-      header.merkle_root = s.raw(32);
-      header.timestamp = new Date(s.readUInt32LE()*1000);
-      header.difficulty = s.readUInt32LE();
-      header.nonce = s.raw(4);
-      header.txn_count = s.readVarInt();
-      headers.push(header);
-    }
-    return { headers: headers };
-  });
+  var s = new Struct(data);
+  var headers = [];
+  var num = s.readVarInt();
+  for (var i = 0; i < num; i++) {
+    var header = {};
+    header.version = s.readUInt32LE();
+    header.prev_block = s.raw(32);
+    header.merkle_root = s.raw(32);
+    header.timestamp = new Date(s.readUInt32LE()*1000);
+    header.difficulty = s.readUInt32LE();
+    header.nonce = s.raw(4);
+    header.txn_count = s.readVarInt();
+    headers.push(header);
+  }
+  return (s.hasFailed)? false : { headers: headers };
 };
 
 BTCNetwork.prototype.invTypes = {
@@ -351,18 +337,17 @@ BTCNetwork.prototype.invTypes = {
   '2': 'block'
 };
 BTCNetwork.prototype.parseInvMessage = function parseInvMessage(data) {
-  return this._wrapStruct(data, function(s) {
-    var items = [];
-    var invNum = s.readVarInt();
-    for (var i = 0; i < invNum; i++) {
-      var inv_vect = {};
-      inv_vect.type = s.readUInt32LE();
-      inv_vect.type_name = (typeof this.invTypes[inv_vect.type] != 'undefined')? this.invTypes[inv_vect.type] : 'unknown';
-      inv_vect.hash = s.raw(32);
-      items.push(inv_vect);
-    }
-    return { items: items };
-  });
+  var s = new Struct(data);
+  var items = [];
+  var invNum = s.readVarInt();
+  for (var i = 0; i < invNum; i++) {
+    var inv_vect = {};
+    inv_vect.type = s.readUInt32LE();
+    inv_vect.type_name = (typeof this.invTypes[inv_vect.type] != 'undefined')? this.invTypes[inv_vect.type] : 'unknown';
+    inv_vect.hash = s.raw(32);
+    items.push(inv_vect);
+  }
+  return (s.hasFailed)? false : { items: items };
 };
 
 BTCNetwork.prototype.handleInvMessage = function handleInvMessage(data, peer) {
@@ -379,9 +364,9 @@ BTCNetwork.prototype.parseNotfoundMessage = function parseNotfoundMessage(data) 
 };
 
 BTCNetwork.prototype.parsePingMessage = function parsePingMessage(data) {
-  return this._wrapStruct(data, function(s) {
-    return { nonce: s.raw(8) };
-  });
+  var s = new Struct(data);
+  var parsed = { nonce: s.raw(8) };
+  return (s.hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handlePingMessage = function handlePingMessage(data, peer) {
@@ -396,59 +381,57 @@ BTCNetwork.prototype.parsePongMessage = function parsePongMessage(data) {
 };
 
 BTCNetwork.prototype.parseTxMessage = function parseTxMessage(data) {
-  return this._wrapStruct(data, function(s) {
-    var parsed = {};
-    parsed.version = s.readUInt32LE();
-    var inCount = s.readVarInt();
-    parsed.txIn = [];
-    for (var i = 0; i < inCount; i++) {
-      var txIn = { outPoint: {} };
-      txIn.outPoint.hash = s.raw(32);
-      txIn.outPoint.index = s.readUInt32LE();
-      var scriptSize = s.readVarInt();
-      txIn.signature = s.raw(scriptSize);
-      txIn.sequence = s.readUInt32LE();
-      parsed.txIn.push(txIn);
+  var s = new Struct(data);
+  var parsed = {};
+  parsed.version = s.readUInt32LE();
+  var inCount = s.readVarInt();
+  parsed.txIn = [];
+  for (var i = 0; i < inCount; i++) {
+    var txIn = { outPoint: {} };
+    txIn.outPoint.hash = s.raw(32);
+    txIn.outPoint.index = s.readUInt32LE();
+    var scriptSize = s.readVarInt();
+    txIn.signature = s.raw(scriptSize);
+    txIn.sequence = s.readUInt32LE();
+    parsed.txIn.push(txIn);
+  }
+  var outCount = s.readVarInt();
+  parsed.txOut = [];
+  for (i = 0; i < outCount; i++) {
+    var txOut = {};
+    txOut.value = s.raw(8);
+    if (tsOut.value !== false && txOut.value.readUInt32LE(4) == 0) {
+      // Actually a 32-bit number
+      txOut.value = txOut.value.readUInt32LE(0);
     }
-    var outCount = s.readVarInt();
-    parsed.txOut = [];
-    for (i = 0; i < outCount; i++) {
-      var txOut = {};
-      txOut.value = s.raw(8);
-      if (tsOut.value !== false && txOut.value.readUInt32LE(4) == 0) {
-        // Actually a 32-bit number
-        txOut.value = txOut.value.readUInt32LE(0);
-      }
-      var scriptSize = s.readVarInt();
-      txOut.script = s.raw(scriptSize);
-      parsed.txOut.push(txOut);
-    }
-    parsed.lock = s.readUInt32LE();
+    var scriptSize = s.readVarInt();
+    txOut.script = s.raw(scriptSize);
+    parsed.txOut.push(txOut);
+  }
+  parsed.lock = s.readUInt32LE();
 
-    parsed.raw = new Buffer(data.length);
-    data.copy(parsed.raw);
-    parsed.hash = new Buffer(sha256.x2(data, { asBytes: true }));
-    return parsed;
-  });
+  parsed.raw = new Buffer(data.length);
+  data.copy(parsed.raw);
+  parsed.hash = new Buffer(sha256.x2(data, { asBytes: true }));
+  return (s.hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.parseVersionMessage = function parseVersionMessage(data, peer) {
-  return this._wrapStruct(data, function(s) {
-    var parsed = {};
-    parsed.version = s.readUInt32LE(0);
-    parsed.services = s.raw(8);
-    parsed.time = s.raw(8);
-    if (parsed.time !== false && parsed.time.readUInt32LE(4) == 0) {
-      // 32-bit date; no need to keep as buffer
-      parsed.time = new Date(parsed.time.readUInt32LE(0)*1000);
-    }
-    parsed.addr_recv = this.getAddr(s.raw(26));
-    parsed.addr_from = this.getAddr(s.raw(26));
-    parsed.nonce = s.raw(8);
-    parsed.client = s.readVarString();
-    parsed.height = s.readUInt32LE();
-    return parsed;
-  });
+  var s = new Struct(data);
+  var parsed = {};
+  parsed.version = s.readUInt32LE(0);
+  parsed.services = s.raw(8);
+  parsed.time = s.raw(8);
+  if (parsed.time !== false && parsed.time.readUInt32LE(4) == 0) {
+    // 32-bit date; no need to keep as buffer
+    parsed.time = new Date(parsed.time.readUInt32LE(0)*1000);
+  }
+  parsed.addr_recv = this.getAddr(s.raw(26));
+  parsed.addr_from = this.getAddr(s.raw(26));
+  parsed.nonce = s.raw(8);
+  parsed.client = s.readVarString();
+  parsed.height = s.readUInt32LE();
+  return (s.hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handleVersionMessage = function handleVersionMessage(data, peer) {

--- a/lib/BTCNetwork.js
+++ b/lib/BTCNetwork.js
@@ -86,7 +86,7 @@ var BTCNetwork = exports.BTCNetwork = function BTCNetwork(options) {
     })
     .on('listenConnect', self.handleListenConnect.bind(self))
     .on('status', function(d) {
-      self.emit('peerStatus', d); // Bubble up!
+      self.emit('status', d); // Bubble up!
     })
     .on('error', function(d) {
       self.emit('error', d); // Bubble up!

--- a/lib/BTCNetwork.js
+++ b/lib/BTCNetwork.js
@@ -154,19 +154,26 @@ BTCNetwork.prototype.handleListenConnect = function handleListenConnect(d) {
 
 //// Message parsing/handling methods ////
 
-BTCNetwork.prototype.parseAddrMessage = function parseAddrMessage(data) {
-  var addrs = [];
-  var raw = new Struct(data);
+BTCNetwork.prototype._wrapStruct = function _wrapStruct(data, func) {
+  var s = new Struct(data);
   var hasFailed = false;
-  raw.on('error', function(err) {
+  s.on('error', function(err) {
     hasFailed = true;
   });
   
-  var addrNum = raw.readVarInt();
-  for (var i = 0; i < addrNum; i++) {
-    addrs.push(this.getAddr(raw.raw(30)));
-  }
-  return (hasFailed)? false : { addrs: addrs };
+  var rs = func.call(this, s);
+  return (hasFailed)? false : rs;
+};
+
+BTCNetwork.prototype.parseAddrMessage = function parseAddrMessage(data) {
+  return this._wrapStruct(data, function(s) {
+    var addrs = [];
+    var addrNum = s.readVarInt();
+    for (var i = 0; i < addrNum; i++) {
+      addrs.push(this.getAddr(s.raw(30)));
+    }
+    return { addrs: addrs };
+  });
 };
 
 BTCNetwork.prototype.handleAddrMessage = function handleAddrMessage(data, peer) {
@@ -174,55 +181,51 @@ BTCNetwork.prototype.handleAddrMessage = function handleAddrMessage(data, peer) 
 };
 
 BTCNetwork.prototype.parseAlertMessage = function parseAlertMessage(data) {
-  var parsed = {};
-  var raw = new Struct(data);
-  var outerFailed = false;
-  raw.on('error', function(err) {
-    outerFailed = true;
+  return this._wrapStruct(data, function(s) {
+    var msgSize = s.readVarInt();
+    var message = s.raw(msgSize);
+    var sigSize = s.readVarInt();
+    var signature = s.raw(sigSize);
+    
+    var parsed = this._wrapStruct(message, function(s) {
+      var parsed = {};
+      parsed.version = s.readUInt32LE();
+      if (parsed.version == 1) {
+        // Original Satoshi client format
+        parsed.relay_until = s.raw(8);
+        if (parsed.relay_until !== false && parsed.relay_until.readUInt32LE(4) == 0) {
+          parsed.relay_until = new Date(parsed.relay_until.readUInt32LE(0)*1000);
+        }
+        parsed.expiration = s.raw(8);
+        if (parsed.expiration !== false && parsed.expiration.readUInt32LE(4) == 0) {
+          parsed.expiration = new Date(parsed.expiration.readUInt32LE(0)*1000);
+        }
+        parsed.uuid = s.readUInt32LE();
+        parsed.cancel = s.readUInt32LE();
+        var num = s.readVarInt();
+        parsed.cancel_set = [];
+        for (var i = 0; i < num; i++) {
+          parsed.cancel_set.push(s.readUInt32LE());
+        }
+        parsed.min_version = s.readUInt32LE();
+        parsed.max_version = s.readUInt32LE();
+        num = s.readVarInt();
+        parsed.subversion_set = [];
+        for (var i = 0; i < num; i++) {
+          parsed.subversion_set.push(s.readVarString());
+        }
+        parsed.priority = s.readUInt32LE();
+        parsed.comment = s.readVarString();
+        parsed.status_bar = s.readVarString();
+        num = s.readVarInt();
+        parsed.reserved = s.raw(num);
+      }
+      return parsed;
+    });
+    if (parsed === false) return false;
+    parsed.signature = signature;
+    return parsed;
   });
-
-  var msgSize = raw.readVarInt();
-  var message = raw.raw(msgSize);
-  var sigSize = raw.readVarInt();
-  parsed.signature = raw.raw(sigSize);
-  
-  message = new Struct(message);
-  var innerFailed = false;
-  message.on('error', function(err) {
-    innerFailed = true;
-  });
-  parsed.version = message.readUInt32LE();
-  if (parsed.version == 1) {
-    // Original Satoshi client format
-    parsed.relay_until = message.raw(8);
-    if (parsed.relay_until.readUInt32LE(4) == 0) {
-      parsed.relay_until = new Date(parsed.relay_until.readUInt32LE(0)*1000);
-    }
-    parsed.expiration = message.raw(8);
-    if (parsed.expiration.readUInt32LE(4) == 0) {
-      parsed.expiration = new Date(parsed.expiration.readUInt32LE(0)*1000);
-    }
-    parsed.uuid = message.readUInt32LE();
-    parsed.cancel = message.readUInt32LE();
-    var num = message.readVarInt();
-    parsed.cancel_set = [];
-    for (var i = 0; i < num; i++) {
-      parsed.cancel_set.push(message.readUInt32LE());
-    }
-    parsed.min_version = message.readUInt32LE();
-    parsed.max_version = message.readUInt32LE();
-    num = message.readVarInt();
-    parsed.subversion_set = [];
-    for (var i = 0; i < num; i++) {
-      parsed.subversion_set.push(message.readVarString());
-    }
-    parsed.priority = message.readUInt32LE();
-    parsed.comment = message.readVarString();
-    parsed.status_bar = message.readVarString();
-    num = message.readVarInt();
-    parsed.reserved = message.raw(num);
-  }
-  return (outerFailed || innerFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handleAlertMessage = function handleAlertMessage(data, peer) {
@@ -311,20 +314,17 @@ BTCNetwork.prototype.handleGetaddrMessage = function handleGetaddrMessage(data, 
 };
 
 BTCNetwork.prototype.parseGetblocksMessage = function parseGetblocksMessage(data) {
-  var parsed = {};
-  var raw = new Struct(data);
-  try {
-    parsed.version = raw.readUInt32LE();
-    var hashCount = raw.readVarInt();
+  return this._wrapStruct(data, function(s) {
+    var parsed = {};
+    parsed.version = s.readUInt32LE();
+    var hashCount = s.readVarInt();
     parsed.hashes = [];
     for (var i = 0; i < hashCount; i++) {
-      parsed.hashes.push(raw.raw(32));
+      parsed.hashes.push(s.raw(32));
     }
-    parsed.hash_stop = raw.raw(32);
-  } catch (e) {
-    return false;
-  }
-  return parsed;
+    parsed.hash_stop = s.raw(32);
+    return parsed;
+  });
 };
 
 BTCNetwork.prototype.parseGetheadersMessage = function parseGetHeadersMessage(data) {
@@ -332,26 +332,22 @@ BTCNetwork.prototype.parseGetheadersMessage = function parseGetHeadersMessage(da
 };
 
 BTCNetwork.prototype.parseHeadersMessage = function parseHeadersMessage(data) {
-  var headers = [];
-  var raw = new Struct(data);
-  var hasFailed = false;
-  raw.on('error', function(err) {
-    hasFailed = true;
+  return this._wrapStruct(data, function(s) {
+    var headers = [];
+    var num = s.readVarInt();
+    for (var i = 0; i < num; i++) {
+      var header = {};
+      header.version = s.readUInt32LE();
+      header.prev_block = s.raw(32);
+      header.merkle_root = s.raw(32);
+      header.timestamp = new Date(s.readUInt32LE()*1000);
+      header.difficulty = s.readUInt32LE();
+      header.nonce = s.raw(4);
+      header.txn_count = s.readVarInt();
+      headers.push(header);
+    }
+    return { headers: headers };
   });
-
-  var num = raw.readVarInt();
-  for (var i = 0; i < num; i++) {
-    var header = {};
-    header.version = raw.readUInt32LE();
-    header.prev_block = raw.raw(32);
-    header.merkle_root = raw.raw(32);
-    header.timestamp = new Date(raw.readUInt32LE()*1000);
-    header.difficulty = raw.readUInt32LE();
-    header.nonce = raw.raw(4);
-    header.txn_count = raw.readVarInt();
-    headers.push(header);
-  }
-  return (hasFailed)? false : { headers: headers };
 };
 
 BTCNetwork.prototype.invTypes = {
@@ -360,22 +356,18 @@ BTCNetwork.prototype.invTypes = {
   '2': 'block'
 };
 BTCNetwork.prototype.parseInvMessage = function parseInvMessage(data) {
-  var items = [];
-  var raw = new Struct(data);
-  var hasFailed = false;
-  raw.on('error', function(err) {
-    hasFailed = true;
+  return this._wrapStruct(data, function(s) {
+    var items = [];
+    var invNum = s.readVarInt();
+    for (var i = 0; i < invNum; i++) {
+      var inv_vect = {};
+      inv_vect.type = s.readUInt32LE();
+      inv_vect.type_name = (typeof this.invTypes[inv_vect.type] != 'undefined')? this.invTypes[inv_vect.type] : 'unknown';
+      inv_vect.hash = s.raw(32);
+      items.push(inv_vect);
+    }
+    return { items: items };
   });
-
-  var invNum = raw.readVarInt();
-  for (var i = 0; i < invNum; i++) {
-    var inv_vect = {};
-    inv_vect.type = raw.readUInt32LE();
-    inv_vect.type_name = (typeof this.invTypes[inv_vect.type] != 'undefined')? this.invTypes[inv_vect.type] : 'unknown';
-    inv_vect.hash = raw.raw(32);
-    items.push(inv_vect);
-  }
-  return (hasFailed)? false : { items: items }
 };
 
 BTCNetwork.prototype.handleInvMessage = function handleInvMessage(data, peer) {
@@ -392,15 +384,9 @@ BTCNetwork.prototype.parseNotfoundMessage = function parseNotfoundMessage(data) 
 };
 
 BTCNetwork.prototype.parsePingMessage = function parsePingMessage(data) {
-  var parsed = {};
-  var raw = new Struct(data);
-  var hasFailed = false;
-  raw.on('error', function(err) {
-    hasFailed = true;
+  return this._wrapStruct(data, function(s) {
+    return { nonce: s.raw(8) };
   });
-
-  parsed.nonce = raw.raw(8);
-  return (hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handlePingMessage = function handlePingMessage(data, peer) {
@@ -415,67 +401,59 @@ BTCNetwork.prototype.parsePongMessage = function parsePongMessage(data) {
 };
 
 BTCNetwork.prototype.parseTxMessage = function parseTxMessage(data) {
-  var parsed = {};
-  var raw = new Struct(data);
-  var hasFailed = false;
-  raw.on('error', function(err) {
-    hasFailed = true;
-  });
-
-  parsed.version = raw.readUInt32LE();
-  var inCount = raw.readVarInt();
-  parsed.txIn = [];
-  for (var i = 0; i < inCount; i++) {
-    var txIn = { outPoint: {} };
-    txIn.outPoint.hash = raw.raw(32);
-    txIn.outPoint.index = raw.readUInt32LE();
-    var scriptSize = raw.readVarInt();
-    txIn.signature = raw.raw(scriptSize);
-    txIn.sequence = raw.readUInt32LE();
-    parsed.txIn.push(txIn);
-  }
-  var outCount = raw.readVarInt();
-  parsed.txOut = [];
-  for (i = 0; i < outCount; i++) {
-    var txOut = {};
-    txOut.value = raw.raw(8);
-    if (tsOut.value !== false && txOut.value.readUInt32LE(4) == 0) {
-      // Actually a 32-bit number
-      txOut.value = txOut.value.readUInt32LE(0);
+  return this._wrapStruct(data, function(s) {
+    var parsed = {};
+    parsed.version = s.readUInt32LE();
+    var inCount = s.readVarInt();
+    parsed.txIn = [];
+    for (var i = 0; i < inCount; i++) {
+      var txIn = { outPoint: {} };
+      txIn.outPoint.hash = s.raw(32);
+      txIn.outPoint.index = s.readUInt32LE();
+      var scriptSize = s.readVarInt();
+      txIn.signature = s.raw(scriptSize);
+      txIn.sequence = s.readUInt32LE();
+      parsed.txIn.push(txIn);
     }
-    var scriptSize = raw.readVarInt();
-    txOut.script = raw.raw(scriptSize);
-    parsed.txOut.push(txOut);
-  }
-  parsed.lock = raw.readUInt32LE();
+    var outCount = s.readVarInt();
+    parsed.txOut = [];
+    for (i = 0; i < outCount; i++) {
+      var txOut = {};
+      txOut.value = s.raw(8);
+      if (tsOut.value !== false && txOut.value.readUInt32LE(4) == 0) {
+        // Actually a 32-bit number
+        txOut.value = txOut.value.readUInt32LE(0);
+      }
+      var scriptSize = s.readVarInt();
+      txOut.script = s.raw(scriptSize);
+      parsed.txOut.push(txOut);
+    }
+    parsed.lock = s.readUInt32LE();
 
-  parsed.raw = new Buffer(data.length);
-  data.copy(parsed.raw);
-  parsed.hash = new Buffer(sha256.x2(data, { asBytes: true }));
-  return (hasFailed)? false : parsed;
+    parsed.raw = new Buffer(data.length);
+    data.copy(parsed.raw);
+    parsed.hash = new Buffer(sha256.x2(data, { asBytes: true }));
+    return parsed;
+  });
 };
 
 BTCNetwork.prototype.parseVersionMessage = function parseVersionMessage(data, peer) {
-  var parsed = {};
-  var raw = new Struct(data);
-  var hasFailed = false;
-  raw.on('error', function(err) {
-    hasFailed = true;
+  return this._wrapStruct(data, function(s) {
+    var parsed = {};
+    parsed.version = s.readUInt32LE(0);
+    parsed.services = s.raw(8);
+    parsed.time = s.raw(8);
+    if (parsed.time !== false && parsed.time.readUInt32LE(4) == 0) {
+      // 32-bit date; no need to keep as buffer
+      parsed.time = new Date(parsed.time.readUInt32LE(0)*1000);
+    }
+    parsed.addr_recv = this.getAddr(s.raw(26));
+    parsed.addr_from = this.getAddr(s.raw(26));
+    parsed.nonce = s.raw(8);
+    parsed.client = s.readVarString();
+    parsed.height = s.readUInt32LE();
+    return parsed;
   });
-
-  parsed.version = raw.readUInt32LE(0);
-  parsed.services = raw.raw(8);
-  parsed.time = raw.raw(8);
-  if (parsed.time !== false && parsed.time.readUInt32LE(4) == 0) {
-    // 32-bit date; no need to keep as buffer
-    parsed.time = new Date(parsed.time.readUInt32LE(0)*1000);
-  }
-  parsed.addr_recv = this.getAddr(raw.raw(26));
-  parsed.addr_from = this.getAddr(raw.raw(26));
-  parsed.nonce = raw.raw(8);
-  parsed.client = raw.readVarString();
-  parsed.height = raw.readUInt32LE();
-  return (hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handleVersionMessage = function handleVersionMessage(data, peer) {

--- a/lib/BTCNetwork.js
+++ b/lib/BTCNetwork.js
@@ -157,15 +157,16 @@ BTCNetwork.prototype.handleListenConnect = function handleListenConnect(d) {
 BTCNetwork.prototype.parseAddrMessage = function parseAddrMessage(data) {
   var addrs = [];
   var raw = new Struct(data);
-  try {
-    var addrNum = raw.readVarInt();
-    for (var i = 0; i < addrNum; i++) {
-      addrs.push(this.getAddr(raw.raw(30)));
-    }
-  } catch (e) {
-    return false;
+  var hasFailed = false;
+  raw.on('error', function(err) {
+    hasFailed = true;
+  });
+  
+  var addrNum = raw.readVarInt();
+  for (var i = 0; i < addrNum; i++) {
+    addrs.push(this.getAddr(raw.raw(30)));
   }
-  return { addrs: addrs };
+  return (hasFailed)? false : { addrs: addrs };
 };
 
 BTCNetwork.prototype.handleAddrMessage = function handleAddrMessage(data, peer) {
@@ -175,48 +176,53 @@ BTCNetwork.prototype.handleAddrMessage = function handleAddrMessage(data, peer) 
 BTCNetwork.prototype.parseAlertMessage = function parseAlertMessage(data) {
   var parsed = {};
   var raw = new Struct(data);
-  try {
-    var msgSize = raw.readVarInt();
-    var message = raw.raw(msgSize);
-    var sigSize = raw.readVarInt();
-    parsed.signature = raw.raw(sigSize);
-    
-    message = new Struct(message);
-    parsed.version = message.readUInt32LE();
-    if (parsed.version == 1) {
-      // Original Satoshi client format
-      parsed.relay_until = message.raw(8);
-      if (parsed.relay_until.readUInt32LE(4) == 0) {
-        parsed.relay_until = new Date(parsed.relay_until.readUInt32LE(0)*1000);
-      }
-      parsed.expiration = message.raw(8);
-      if (parsed.expiration.readUInt32LE(4) == 0) {
-        parsed.expiration = new Date(parsed.expiration.readUInt32LE(0)*1000);
-      }
-      parsed.uuid = message.readUInt32LE();
-      parsed.cancel = message.readUInt32LE();
-      var num = message.readVarInt();
-      parsed.cancel_set = [];
-      for (var i = 0; i < num; i++) {
-        parsed.cancel_set.push(message.readUInt32LE());
-      }
-      parsed.min_version = message.readUInt32LE();
-      parsed.max_version = message.readUInt32LE();
-      num = message.readVarInt();
-      parsed.subversion_set = [];
-      for (var i = 0; i < num; i++) {
-        parsed.subversion_set.push(message.readVarString());
-      }
-      parsed.priority = message.readUInt32LE();
-      parsed.comment = message.readVarString();
-      parsed.status_bar = message.readVarString();
-      num = message.readVarInt();
-      parsed.reserved = message.raw(num);
+  var outerFailed = false;
+  raw.on('error', function(err) {
+    outerFailed = true;
+  });
+
+  var msgSize = raw.readVarInt();
+  var message = raw.raw(msgSize);
+  var sigSize = raw.readVarInt();
+  parsed.signature = raw.raw(sigSize);
+  
+  message = new Struct(message);
+  var innerFailed = false;
+  message.on('error', function(err) {
+    innerFailed = true;
+  });
+  parsed.version = message.readUInt32LE();
+  if (parsed.version == 1) {
+    // Original Satoshi client format
+    parsed.relay_until = message.raw(8);
+    if (parsed.relay_until.readUInt32LE(4) == 0) {
+      parsed.relay_until = new Date(parsed.relay_until.readUInt32LE(0)*1000);
     }
-  } catch(e) {
-    return false;
+    parsed.expiration = message.raw(8);
+    if (parsed.expiration.readUInt32LE(4) == 0) {
+      parsed.expiration = new Date(parsed.expiration.readUInt32LE(0)*1000);
+    }
+    parsed.uuid = message.readUInt32LE();
+    parsed.cancel = message.readUInt32LE();
+    var num = message.readVarInt();
+    parsed.cancel_set = [];
+    for (var i = 0; i < num; i++) {
+      parsed.cancel_set.push(message.readUInt32LE());
+    }
+    parsed.min_version = message.readUInt32LE();
+    parsed.max_version = message.readUInt32LE();
+    num = message.readVarInt();
+    parsed.subversion_set = [];
+    for (var i = 0; i < num; i++) {
+      parsed.subversion_set.push(message.readVarString());
+    }
+    parsed.priority = message.readUInt32LE();
+    parsed.comment = message.readVarString();
+    parsed.status_bar = message.readVarString();
+    num = message.readVarInt();
+    parsed.reserved = message.raw(num);
   }
-  return parsed;
+  return (outerFailed || innerFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handleAlertMessage = function handleAlertMessage(data, peer) {
@@ -328,23 +334,24 @@ BTCNetwork.prototype.parseGetheadersMessage = function parseGetHeadersMessage(da
 BTCNetwork.prototype.parseHeadersMessage = function parseHeadersMessage(data) {
   var headers = [];
   var raw = new Struct(data);
-  try {
-    var num = raw.readVarInt();
-    for (var i = 0; i < num; i++) {
-      var header = {};
-      header.version = raw.readUInt32LE();
-      header.prev_block = raw.raw(32);
-      header.merkle_root = raw.raw(32);
-      header.timestamp = new Date(raw.readUInt32LE()*1000);
-      header.difficulty = raw.readUInt32LE();
-      header.nonce = raw.raw(4);
-      header.txn_count = raw.readVarInt();
-      headers.push(header);
-    }
-  } catch (e) {
-    return false;
+  var hasFailed = false;
+  raw.on('error', function(err) {
+    hasFailed = true;
+  });
+
+  var num = raw.readVarInt();
+  for (var i = 0; i < num; i++) {
+    var header = {};
+    header.version = raw.readUInt32LE();
+    header.prev_block = raw.raw(32);
+    header.merkle_root = raw.raw(32);
+    header.timestamp = new Date(raw.readUInt32LE()*1000);
+    header.difficulty = raw.readUInt32LE();
+    header.nonce = raw.raw(4);
+    header.txn_count = raw.readVarInt();
+    headers.push(header);
   }
-  return { headers: headers };
+  return (hasFailed)? false : { headers: headers };
 };
 
 BTCNetwork.prototype.invTypes = {
@@ -355,19 +362,20 @@ BTCNetwork.prototype.invTypes = {
 BTCNetwork.prototype.parseInvMessage = function parseInvMessage(data) {
   var items = [];
   var raw = new Struct(data);
-  try {
-    var invNum = raw.readVarInt();
-    for (var i = 0; i < invNum; i++) {
-      var inv_vect = {};
-      inv_vect.type = raw.readUInt32LE();
-      inv_vect.type_name = (typeof this.invTypes[inv_vect.type] != 'undefined')? this.invTypes[inv_vect.type] : 'unknown';
-      inv_vect.hash = raw.raw(32);
-      items.push(inv_vect);
-    }
-  } catch(e) {
-    return false;
+  var hasFailed = false;
+  raw.on('error', function(err) {
+    hasFailed = true;
+  });
+
+  var invNum = raw.readVarInt();
+  for (var i = 0; i < invNum; i++) {
+    var inv_vect = {};
+    inv_vect.type = raw.readUInt32LE();
+    inv_vect.type_name = (typeof this.invTypes[inv_vect.type] != 'undefined')? this.invTypes[inv_vect.type] : 'unknown';
+    inv_vect.hash = raw.raw(32);
+    items.push(inv_vect);
   }
-  return { items: items }
+  return (hasFailed)? false : { items: items }
 };
 
 BTCNetwork.prototype.handleInvMessage = function handleInvMessage(data, peer) {
@@ -386,12 +394,13 @@ BTCNetwork.prototype.parseNotfoundMessage = function parseNotfoundMessage(data) 
 BTCNetwork.prototype.parsePingMessage = function parsePingMessage(data) {
   var parsed = {};
   var raw = new Struct(data);
-  try {
-    parsed.nonce = raw.raw(8);
-  } catch(e) {
-    return false;
-  }
-  return parsed;
+  var hasFailed = false;
+  raw.on('error', function(err) {
+    hasFailed = true;
+  });
+
+  parsed.nonce = raw.raw(8);
+  return (hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handlePingMessage = function handlePingMessage(data, peer) {
@@ -407,65 +416,66 @@ BTCNetwork.prototype.parsePongMessage = function parsePongMessage(data) {
 
 BTCNetwork.prototype.parseTxMessage = function parseTxMessage(data) {
   var parsed = {};
-  
   var raw = new Struct(data);
-  try {
-    parsed.version = raw.readUInt32LE();
-    var inCount = raw.readVarInt();
-    parsed.txIn = [];
-    for (var i = 0; i < inCount; i++) {
-      var txIn = { outPoint: {} };
-      txIn.outPoint.hash = raw.raw(32);
-      txIn.outPoint.index = raw.readUInt32LE();
-      var scriptSize = raw.readVarInt();
-      txIn.signature = raw.raw(scriptSize);
-      txIn.sequence = raw.readUInt32LE();
-      parsed.txIn.push(txIn);
-    }
-    var outCount = raw.readVarInt();
-    parsed.txOut = [];
-    for (i = 0; i < outCount; i++) {
-      var txOut = {};
-      txOut.value = raw.raw(8);
-      if (txOut.value.readUInt32LE(4) == 0) {
-        // Actually a 32-bit number
-        txOut.value = txOut.value.readUInt32LE(0);
-      }
-      var scriptSize = raw.readVarInt();
-      txOut.script = raw.raw(scriptSize);
-      parsed.txOut.push(txOut);
-    }
-    parsed.lock = raw.readUInt32LE();
-  
-    parsed.raw = new Buffer(data.length);
-    data.copy(parsed.raw);
-    parsed.hash = new Buffer(sha256.x2(data, { asBytes: true }));
-  } catch(e) {
-    return false;
+  var hasFailed = false;
+  raw.on('error', function(err) {
+    hasFailed = true;
+  });
+
+  parsed.version = raw.readUInt32LE();
+  var inCount = raw.readVarInt();
+  parsed.txIn = [];
+  for (var i = 0; i < inCount; i++) {
+    var txIn = { outPoint: {} };
+    txIn.outPoint.hash = raw.raw(32);
+    txIn.outPoint.index = raw.readUInt32LE();
+    var scriptSize = raw.readVarInt();
+    txIn.signature = raw.raw(scriptSize);
+    txIn.sequence = raw.readUInt32LE();
+    parsed.txIn.push(txIn);
   }
-  return parsed;
+  var outCount = raw.readVarInt();
+  parsed.txOut = [];
+  for (i = 0; i < outCount; i++) {
+    var txOut = {};
+    txOut.value = raw.raw(8);
+    if (tsOut.value !== false && txOut.value.readUInt32LE(4) == 0) {
+      // Actually a 32-bit number
+      txOut.value = txOut.value.readUInt32LE(0);
+    }
+    var scriptSize = raw.readVarInt();
+    txOut.script = raw.raw(scriptSize);
+    parsed.txOut.push(txOut);
+  }
+  parsed.lock = raw.readUInt32LE();
+
+  parsed.raw = new Buffer(data.length);
+  data.copy(parsed.raw);
+  parsed.hash = new Buffer(sha256.x2(data, { asBytes: true }));
+  return (hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.parseVersionMessage = function parseVersionMessage(data, peer) {
   var parsed = {};
   var raw = new Struct(data);
-  try {
-    parsed.version = raw.readUInt32LE(0);
-    parsed.services = raw.raw(8);
-    parsed.time = raw.raw(8);
-    if (parsed.time.readUInt32LE(4) == 0) {
-      // 32-bit date; no need to keep as buffer
-      parsed.time = new Date(parsed.time.readUInt32LE(0)*1000);
-    }
-    parsed.addr_recv = this.getAddr(raw.raw(26));
-    parsed.addr_from = this.getAddr(raw.raw(26));
-    parsed.nonce = raw.raw(8);
-    parsed.client = raw.readVarString();
-    parsed.height = raw.readUInt32LE();
-  } catch(e) {
-    return false;
+  var hasFailed = false;
+  raw.on('error', function(err) {
+    hasFailed = true;
+  });
+
+  parsed.version = raw.readUInt32LE(0);
+  parsed.services = raw.raw(8);
+  parsed.time = raw.raw(8);
+  if (parsed.time !== false && parsed.time.readUInt32LE(4) == 0) {
+    // 32-bit date; no need to keep as buffer
+    parsed.time = new Date(parsed.time.readUInt32LE(0)*1000);
   }
-  return parsed;
+  parsed.addr_recv = this.getAddr(raw.raw(26));
+  parsed.addr_from = this.getAddr(raw.raw(26));
+  parsed.nonce = raw.raw(8);
+  parsed.client = raw.readVarString();
+  parsed.height = raw.readUInt32LE();
+  return (hasFailed)? false : parsed;
 };
 
 BTCNetwork.prototype.handleVersionMessage = function handleVersionMessage(data, peer) {

--- a/lib/BTCNetwork.js
+++ b/lib/BTCNetwork.js
@@ -400,7 +400,7 @@ BTCNetwork.prototype.parseTxMessage = function parseTxMessage(data) {
   for (i = 0; i < outCount; i++) {
     var txOut = {};
     txOut.value = s.raw(8);
-    if (tsOut.value !== false && txOut.value.readUInt32LE(4) == 0) {
+    if (txOut.value !== false && txOut.value.readUInt32LE(4) == 0) {
       // Actually a 32-bit number
       txOut.value = txOut.value.readUInt32LE(0);
     }

--- a/lib/Struct.js
+++ b/lib/Struct.js
@@ -1,8 +1,4 @@
-var events = require('events');
-var util = require('util');
-
 var Struct = exports.Struct = function Struct(raw) {
-  events.EventEmitter.call(this);
   Object.defineProperty(this, 'buffer', {
     enumerable: true,
     value: new Buffer(raw.length)
@@ -12,12 +8,10 @@ var Struct = exports.Struct = function Struct(raw) {
   this.pointer = 0;
   this.hasFailed = false;
 };
-util.inherits(Struct, events.EventEmitter);
 
 Struct.prototype.pointerCheck = function pointerCheck(num) {
   num = +num || 0;
   if (this.buffer.length < this.pointer+num) {
-    this.emit('error');
     this.hasFailed = true;
     return false;
   }

--- a/lib/Struct.js
+++ b/lib/Struct.js
@@ -10,6 +10,7 @@ var Struct = exports.Struct = function Struct(raw) {
   raw.copy(this.buffer);
   
   this.pointer = 0;
+  this.hasFailed = false;
 };
 util.inherits(Struct, events.EventEmitter);
 
@@ -17,42 +18,46 @@ Struct.prototype.pointerCheck = function pointerCheck(num) {
   num = +num || 0;
   if (this.buffer.length < this.pointer+num) {
     this.emit('error');
+    this.hasFailed = true;
+    return false;
   }
 };
 
 Struct.prototype.incrPointer = function incrPointer(amount) {
+  if (this.hasFailed) return false;
   this.pointer += amount;
   this.pointerCheck();
 };
 
 Struct.prototype.setPointer = function setPointer(amount) {
+  if (this.hasFailed) return false;
   this.pointer = amount;
   this.pointerCheck();
 };
 
 Struct.prototype.readInt8 = function readInt8() {
-  this.pointerCheck();
+  if (this.hasFailed || this.pointerCheck() === false) return false;
   var out = this.buffer[this.pointer];
   this.incrPointer(1);
   return out;
 };
 
 Struct.prototype.readUInt16LE = function readUInt16LE() {
-  this.pointerCheck(2);
+  if (this.hasFailed || this.pointerCheck(2) === false) return false;
   var out = this.buffer.readUInt16LE(this.pointer);
   this.incrPointer(2);
   return out
 };
 
 Struct.prototype.readUInt32LE = function readUInt32LE() {
-  this.pointerCheck(4);
+  if (this.hasFailed || this.pointerCheck(4) === false) return false;
   var out = this.buffer.readUInt32LE(this.pointer);
   this.incrPointer(4);
   return out
 };
 
 Struct.prototype.readVarInt = function readVarInt() {
-  this.pointerCheck();
+  if (this.hasFailed || this.pointerCheck() === false) return false;
   var flag = this.readInt8();
   if (flag < 0xfd) {
     return flag;
@@ -66,6 +71,7 @@ Struct.prototype.readVarInt = function readVarInt() {
 };
 
 Struct.prototype.readVarString = function readVarString() {
+  if (this.hasFailed || this.pointerCheck() === false) return false;
   var length = this.readVarInt();
   var str = [];
   for (var i = 0; i < length; i++) {
@@ -75,7 +81,7 @@ Struct.prototype.readVarString = function readVarString() {
 }
 
 Struct.prototype.raw = function raw(length) {
-  this.pointerCheck(length);
+  if (this.hasFailed || this.pointerCheck(length) === false) return false;
   var out = new Buffer(length);
   this.buffer.copy(out, 0, this.pointer, this.pointer+length);
   this.incrPointer(length);

--- a/test/btcnetwork.test.js
+++ b/test/btcnetwork.test.js
@@ -16,6 +16,9 @@ describe('BTCNetwork', function() {
     assert.equal(addrs[0].host, '82.95.140.37');
     assert.equal(addrs[0].port, 8333);
   });
+  it('should properly reject a badly-formatted ADDR message', function() {
+    assert.equal(n.parseAddrMessage(new Buffer('0102030405', 'hex')), false);
+  });
   it('should properly parse an ALERT message', function() {
     var test = n.parseAlertMessage(new Buffer('73010000003766404f00000000b305434f00000000f2030000f1030000001027000048ee00000064000000004653656520626974636f696e2e6f72672f666562323020696620796f7520686176652074726f75626c6520636f6e6e656374696e67206166746572203230204665627275617279004730450221008389df45f0703f39ec8c1cc42c13810ffcae14995bb648340219e353b63b53eb022009ec65e1c1aaeec1fd334c6b684bde2b3f573060d5b70c3a46723326e4e8a4f1', 'hex'));
     assert.notEqual(test, false);
@@ -37,6 +40,18 @@ describe('BTCNetwork', function() {
     assert.equal(test.reserved.toString('hex'), '');
     assert.equal(test.signature.toString('hex'), '30450221008389df45f0703f39ec8c1cc42c13810ffcae14995bb648340219e353b63b53eb022009ec65e1c1aaeec1fd334c6b684bde2b3f573060d5b70c3a46723326e4e8a4f1');
   });
+  it('should properly reject a badly-formatted ALERT message', function() {
+    assert.equal(n.parseAlertMessage(new Buffer('0102030405', 'hex')), false);
+  });
+  it('should properly reject a badly-formatted GETBLOCKS message', function() {
+    assert.equal(n.parseGetblocksMessage(new Buffer('0102030405', 'hex')), false);
+  });
+  it('should properly reject a badly-formatted GETHEADERS message', function() {
+    assert.equal(n.parseGetheadersMessage(new Buffer('0102030405', 'hex')), false);
+  });
+  it('should properly reject a badly-formatted HEADERS message', function() {
+    assert.equal(n.parseHeadersMessage(new Buffer('0102030405', 'hex')), false);
+  });
   it('should properly parse an INV message', function() {
     var test = n.parseInvMessage(new Buffer('0101000000f2bc363cb9ddc6d29beef22c91305da25a88cbb7272dc099c33a75baebfc8c14', 'hex'));
     var items = test.items;
@@ -44,6 +59,18 @@ describe('BTCNetwork', function() {
     assert.equal(items.length, 1);
     assert.equal(items[0].type, 1);
     assert.equal(items[0].hash.toString('hex'), 'f2bc363cb9ddc6d29beef22c91305da25a88cbb7272dc099c33a75baebfc8c14');
+  });
+  it('should properly reject a badly-formatted INV message', function() {
+    assert.equal(n.parseInvMessage(new Buffer('0102030405', 'hex')), false);
+  });
+  it('should properly reject a badly-formatted NOTFOUND message', function() {
+    assert.equal(n.parseNotfoundMessage(new Buffer('0102030405', 'hex')), false);
+  });
+  it('should properly reject a badly-formatted PING message', function() {
+    assert.equal(n.parsePingMessage(new Buffer('0102030405', 'hex')), false);
+  });
+  it('should properly reject a badly-formatted TX message', function() {
+    assert.equal(n.parseTxMessage(new Buffer('0102030405', 'hex')), false);
   });
   it('should properly parse a VERSION message', function() {
     var test = n.parseVersionMessage(new Buffer('7111010001000000000000006017d65200000000010000000000000000000000000000000000ffff4581caaac2e7010000000000000000000000000000000000ffffb78d744f208d351351d2b1e1b0400f2f5361746f7368693a302e382e352fec470400', 'hex'), p);
@@ -59,5 +86,8 @@ describe('BTCNetwork', function() {
     assert.equal(test.nonce.toString('hex'),  '351351d2b1e1b040');
     assert.equal(test.client, '/Satoshi:0.8.5/');
     assert.equal(test.height, 280556);
+  });
+  it('should properly reject a badly-formatted VERSION message', function() {
+    assert.equal(n.parseVersionMessage(new Buffer('0102030405', 'hex')), false);
   });
 });

--- a/test/btcnetwork.test.js
+++ b/test/btcnetwork.test.js
@@ -63,17 +63,53 @@ describe('BTCNetwork', function() {
   it('should properly reject a badly-formatted INV message', function() {
     assert.equal(n.parseInvMessage(new Buffer('0102030405', 'hex')), false);
   });
+  it('should properly parse a NOTFOUND message', function() {
+    var test = n.parseNotfoundMessage(new Buffer('0101000000f2bc363cb9ddc6d29beef22c91305da25a88cbb7272dc099c33a75baebfc8c14', 'hex'));
+    var items = test.items;
+    assert.ok(Array.isArray(items));
+    assert.equal(items.length, 1);
+    assert.equal(items[0].type, 1);
+    assert.equal(items[0].hash.toString('hex'), 'f2bc363cb9ddc6d29beef22c91305da25a88cbb7272dc099c33a75baebfc8c14');
+  });
   it('should properly reject a badly-formatted NOTFOUND message', function() {
     assert.equal(n.parseNotfoundMessage(new Buffer('0102030405', 'hex')), false);
+  });
+  it('should properly parse a PING message', function() {
+    var test = n.parsePingMessage(new Buffer('0102030405060708', 'hex'));
+    assert.ok(Buffer.isBuffer(test.nonce));
+    assert.equal(test.nonce.toString('hex'), '0102030405060708');
   });
   it('should properly reject a badly-formatted PING message', function() {
     assert.equal(n.parsePingMessage(new Buffer('0102030405', 'hex')), false);
   });
+  it('should properly parse a TX message', function() {
+    var test = n.parseTxMessage(new Buffer('01000000016DBDDB085B1D8AF75184F0BC01FAD58D1266E9B63B50881990E4B40D6AEE3629000000008B483045022100F3581E1972AE8AC7C7367A7A253BC1135223ADB9A468BB3A59233F45BC578380022059AF01CA17D00E41837A1D58E97AA31BAE584EDEC28D35BD96923690913BAE9A0141049C02BFC97EF236CE6D8FE5D94013C721E915982ACD2B12B65D9B7D59E20A842005F8FC4E02532E873D37B96F09D6D4511ADA8F14042F46614A4C70C0F14BEFF5FFFFFFFF02404B4C00000000001976A9141AA0CD1CBEA6E7458A7ABAD512A9D9EA1AFB225E88AC80FAE9C7000000001976A9140EAB5BEA436A0484CFAB12485EFDA0B78B4ECC5288AC00000000', 'hex'));
+    assert.equal(test.version, 1);
+    assert.ok(Array.isArray(test.txIn));
+    assert.equal(test.txIn.length, 1);
+    assert.ok(Array.isArray(test.txOut));
+    assert.ok(Buffer.isBuffer(test.txIn[0].outPoint.hash));
+    assert.equal(test.txIn[0].outPoint.hash.toString('hex'), '6dbddb085b1d8af75184f0bc01fad58d1266e9b63b50881990e4b40d6aee3629');
+    assert.equal(test.txIn[0].outPoint.index, 0);
+    assert.ok(Buffer.isBuffer(test.txIn[0].signature));
+    assert.equal(test.txIn[0].signature.toString('hex'), '483045022100f3581e1972ae8ac7c7367a7a253bc1135223adb9a468bb3a59233f45bc578380022059af01ca17d00e41837a1d58e97aa31bae584edec28d35bd96923690913bae9a0141049c02bfc97ef236ce6d8fe5d94013c721e915982acd2b12b65d9b7d59e20a842005f8fc4e02532e873d37b96f09d6d4511ada8f14042f46614a4c70c0f14beff5');
+    assert.equal(test.txIn[0].sequence, 0xFFFFFFFF);
+    assert.equal(test.txOut.length, 2);
+    assert.equal(test.txOut[0].value, 5000000);
+    assert.ok(Buffer.isBuffer(test.txOut[0].script));
+    assert.equal(test.txOut[0].script.toString('hex'), '76a9141aa0cd1cbea6e7458a7abad512a9d9ea1afb225e88ac');
+    assert.equal(test.txOut[1].value, 3354000000);
+    assert.ok(Buffer.isBuffer(test.txOut[1].script));
+    assert.equal(test.txOut[1].script.toString('hex'), '76a9140eab5bea436a0484cfab12485efda0b78b4ecc5288ac');
+    assert.equal(test.lock, 0);
+    assert.ok(Buffer.isBuffer(test.raw));
+    assert.equal(test.hash.toString('hex'), 'e293cdbee28102c38ee58814466c666146b3fad10505cfb4ace77eab513fa7d4');
+  })
   it('should properly reject a badly-formatted TX message', function() {
     assert.equal(n.parseTxMessage(new Buffer('0102030405', 'hex')), false);
   });
   it('should properly parse a VERSION message', function() {
-    var test = n.parseVersionMessage(new Buffer('7111010001000000000000006017d65200000000010000000000000000000000000000000000ffff4581caaac2e7010000000000000000000000000000000000ffffb78d744f208d351351d2b1e1b0400f2f5361746f7368693a302e382e352fec470400', 'hex'), p);
+    var test = n.parseVersionMessage(new Buffer('7111010001000000000000006017d65200000000010000000000000000000000000000000000ffff4581caaac2e7010000000000000000000000000000000000ffffb78d744f208d351351d2b1e1b0400f2f5361746f7368693a302e382e352fec470400', 'hex'));
     assert.equal(test.version, 70001);
     assert.equal(test.services.readUInt32LE(0), 1);
     assert.equal(test.time.getTime(), 1389762400000);

--- a/test/struct.test.js
+++ b/test/struct.test.js
@@ -2,19 +2,17 @@ var Struct = require('../lib/Struct').Struct;
 var assert = require("assert")
 
 describe('Struct', function() {
-  it('should emit error on increment overflow', function() {
+  it('should fail on increment overflow', function() {
     var s = new Struct(new Buffer(10));
-    assert.throws(function() {
-      for (var i = 0; i < 11; i++) {
-        s.incrPointer(1);
-      }
-    });
+    for (var i = 0; i < 11; i++) {
+      s.incrPointer(1);
+    }
+    assert.equal(s.hasFailed, true);
   });
-  it('should emit error on set overflow', function() {
+  it('should fail on set overflow', function() {
     var s = new Struct(new Buffer(10));
-    assert.throws(function() {
-      s.setPointer(11);
-    });
+    s.setPointer(11);
+    assert.equal(s.hasFailed, true);
   });
   it('readInt8() should return sequential 8-bit numbers', function() {
     var s = new Struct(new Buffer([1,2,3,4,5]));
@@ -22,7 +20,8 @@ describe('Struct', function() {
     for (var i = 0; i < 5; i++) {
       test.push(s.readInt8());
     }
-    assert.equal('1,2,3,4,5', test.join(','));
+    assert.equal(test.join(','), '1,2,3,4,5');
+    assert.equal(s.hasFailed, false);
   });
   it('readUInt16LE() should return sequential 16-bit numbers', function() {
     var s = new Struct(new Buffer([1,0,2,0,3,0,4,0,5,0]));
@@ -30,7 +29,8 @@ describe('Struct', function() {
     for (var i = 0; i < 5; i++) {
       test.push(s.readUInt16LE());
     }
-    assert.equal('1,2,3,4,5', test.join(','));
+    assert.equal(test.join(','), '1,2,3,4,5');
+    assert.equal(s.hasFailed, false);
   });
   it('readUInt32LE() should return sequential 32-bit numbers', function() {
     var s = new Struct(new Buffer([1,0,0,0,2,0,0,0,3,0,0,0,4,0,0,0,5,0,0,0]));
@@ -38,7 +38,8 @@ describe('Struct', function() {
     for (var i = 0; i < 5; i++) {
       test.push(s.readUInt32LE());
     }
-    assert.equal('1,2,3,4,5', test.join(','));
+    assert.equal(test.join(','), '1,2,3,4,5');
+    assert.equal(s.hasFailed, false);
   });
   describe('readVarInt()', function() {
     it('should parse 8-bit numbers', function() {
@@ -47,7 +48,8 @@ describe('Struct', function() {
       for (var i = 0; i < 5; i++) {
         test.push(s.readVarInt());
       }
-      assert.equal('1,2,3,4,5', test.join(','));
+      assert.equal(test.join(','), '1,2,3,4,5');
+      assert.equal(s.hasFailed, false);
     });
     it('should parse 16-bit numbers', function() {
       var s = new Struct(new Buffer([253,1,0,253,2,0,253,3,0,253,4,0,253,5,0]));
@@ -55,7 +57,8 @@ describe('Struct', function() {
       for (var i = 0; i < 5; i++) {
         test.push(s.readVarInt());
       }
-      assert.equal('1,2,3,4,5', test.join(','));
+      assert.equal(test.join(','), '1,2,3,4,5');
+      assert.equal(s.hasFailed, false);
     });
     it('should parse 32-bit numbers', function() {
       var s = new Struct(new Buffer([254,1,0,0,0,254,2,0,0,0,254,3,0,0,0,254,4,0,0,0,254,5,0,0,0]));
@@ -63,7 +66,8 @@ describe('Struct', function() {
       for (var i = 0; i < 5; i++) {
         test.push(s.readVarInt());
       }
-      assert.equal('1,2,3,4,5', test.join(','));
+      assert.equal(test.join(','), '1,2,3,4,5');
+      assert.equal(s.hasFailed, false);
     });
     it('should parse 64-bit numbers', function() {
       var s = new Struct(new Buffer([255,1,0,0,0,0,0,0,0,255,2,0,0,0,0,0,0,0,255,3,0,0,0,0,0,0,0,255,4,0,0,0,0,0,0,0,255,5,0,0,0,0,0,0,0]));
@@ -71,26 +75,29 @@ describe('Struct', function() {
       for (var i = 0; i < 5; i++) {
         var rs = s.readVarInt();
         assert.ok(Buffer.isBuffer(rs));
-        assert.equal(8, rs.length);
-        assert.equal(0, rs.readUInt32LE(4));
+        assert.equal(rs.length, 8);
+        assert.equal(rs.readUInt32LE(4), 0);
         test.push(rs.readUInt32LE(0));
       }
-      assert.equal('1,2,3,4,5', test.join(','));
+      assert.equal(test.join(','), '1,2,3,4,5');
+      assert.equal(s.hasFailed, false);
     });
   });
   it('readVarString() should return proper result', function() {
     var s = new Struct(new Buffer('0F2F5361746F7368693A302E372E322F', 'hex'));
-    assert.equal("/Satoshi:0.7.2/", s.readVarString());
+    assert.equal(s.readVarString(), '/Satoshi:0.7.2/');
+    assert.equal(s.hasFailed, false);
   });
   it('raw() should return a new Buffer', function() {
     var s = new Struct(new Buffer([1,2,3,4,5]));
     var test = s.raw(3);
     assert.ok(Buffer.isBuffer(test));
-    assert.equal(3, test.length);
-    assert.equal('010203', test.toString('hex'));
+    assert.equal(test.length, 3);
+    assert.equal(test.toString('hex'), '010203');
     test[1] = 255; // set value in the result
     s.setPointer(1);
-    assert.equal(2, s.readInt8()); // old value should be unaffected
+    assert.equal(s.readInt8(), 2); // old value should be unaffected
+    assert.equal(s.hasFailed, false);
   })
 });
  


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Issues fixed by this | #1 |

Fixes #1 by using an internal `hasFailed` flag to tell what to return.
# Tasks
- [x] Write more test cases for valid examples
- [x] Changelog updated
- [x] Usage/Documentation updated
- [x] Tests pass
- [ ] ACK from other developers
